### PR TITLE
feat: Add Sphinx documentation and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Or your default branch
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10' # Should match project's Python version
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install sphinx sphinx_rtd_theme m2r2
+
+      - name: Build Sphinx documentation
+        run: |
+          sphinx-build -b html docs docs/_build/html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/_build/html'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
+# Sphinx documentation build output
 docs/_build/
+docs/api/
 
 # PyBuilder
 .pybuilder/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,42 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..')) # Add project root
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'multiext'
+copyright = '2025, ikkebr (from pyproject.toml)'
+author = 'ikkebr (from pyproject.toml)'
+
+version = '0.2.1'
+release = '0.2.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx_rtd_theme',
+    'm2r2'
+]
+
+source_suffix = ['.rst', '.md']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,14 @@
+.. mdinclude:: ../README.md
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   Home <self>
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference:
+
+   api/multiext
+   api/modules

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,6 @@
 pytest
 pytest-cov
+
+sphinx
+sphinx_rtd_theme
+m2r2


### PR DESCRIPTION
This commit introduces Sphinx for project documentation.

Key changes:
- Initializes a Sphinx project in the `docs/` directory.
- Configures Sphinx to:
    - Use the `sphinx_rtd_theme`.
    - Pull API documentation from docstrings in the `multiext` package via `sphinx.ext.autodoc` and `sphinx.ext.napoleon`.
    - Allow Markdown inclusion using `m2r2`.
- Generates API documentation stubs for all modules in `multiext` using `sphinx-apidoc`.
- Updates `docs/index.rst` to include the project's `README.md` and a table of contents for the API documentation.
- Adds a GitHub Actions workflow (`.github/workflows/docs.yml`) to automatically build the documentation and deploy it to GitHub Pages on pushes to the `main` branch.
- Updates `requirements-dev.txt` with `sphinx`, `sphinx_rtd_theme`, and `m2r2`.
- Updates `.gitignore` to exclude Sphinx build artifacts (`docs/_build/`) and generated API stubs (`docs/api/`).

The documentation can now be generated by running `sphinx-build -b html docs docs/_build/html` and will be automatically deployed to GitHub Pages.